### PR TITLE
Implement AssignResources command

### DIFF
--- a/tmcprototype/CentralNode/CentralNode.xmi
+++ b/tmcprototype/CentralNode/CentralNode.xmi
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="CentralNode" pogoRevision="9.4">
-    <description description="Central Node is a coordinator of the complete M&amp;C system." title="CentralNode" sourcePath="/home/rajiv/tmc-prototype/tmc-prototype/CentralNode" language="PythonHL" filestogenerate="XMI   file,Code files,Python Package,Protected Regions,Sphinx,html Pages" license="BSD-3-Clause" copyright="" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false" descriptionHtmlExists="false">
+    <description description="Central Node is a coordinator of the complete M&amp;C system." title="CentralNode" sourcePath="/home/user/projects/tmc-prototype/tmcprototype/CentralNode" language="PythonHL" filestogenerate="XMI   file,Code files,Protected Regions" license="BSD-3-Clause" copyright="" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_Impl" sourcePath=""/>
-      <inheritances classname="SKABaseDevice" sourcePath="../../../tmc-prototype_old/lmc-base-classes/skabase/SKABaseDevice"/>
+      <inheritances classname="SKABaseDevice" sourcePath="../../../lmc-base-classes/skabase/SKABaseDevice"/>
       <identification contact="at gmail.com - apurva.ska" author="apurva.ska" emailDomain="gmail.com" classFamily="Training" siteSpecific="" platform="All Platforms" bus="Not Applicable" manufacturer="none" reference=""/>
     </description>
     <deviceProperties name="SkaLevel" description="Indication of importance of the device in the SKA hierarchy &#xA;to support drill-down navigation: 1..6, with 1 highest.&#xA;Default is 4, making provision for &#xA;EltMaster, EltAlarms, EltTelState = 1&#xA;SubEltMaster = 2&#xA;Subarray, Capability = 2/3&#xA;Others = 4 (or 5 or 6)">
@@ -140,6 +140,15 @@
       </argout>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </commands>
+    <commands name="AssignResources" description="This command assigns resources to given subarray. It accepts the subarray id and receptor id list as JSON string." execMethod="assign_resources" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
+      <argin description="The string in JSON format. The JSON contains following values:&#xA;subarrayID: DevShort&#xA;dish: JSON object consisting&#xA;- receptorIDList: DevVarStringArray. The individual string should contain dish numbers in string format with preceding zeroes upto 3 digits. E.g. 0001, 0002">
+        <type xsi:type="pogoDsl:StringType"/>
+      </argin>
+      <argout description="None.">
+        <type xsi:type="pogoDsl:VoidType"/>
+      </argout>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+    </commands>
     <attributes name="buildState" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="60000" maxX="" maxY="" allocReadMember="true">
       <dataType xsi:type="pogoDsl:StringType"/>
       <status abstract="false" inherited="true" concrete="true"/>
@@ -266,6 +275,6 @@
     <states name="DISABLE" description="The device cannot be switched ON for an external reason. E.g. the power supply has its door open, the safety conditions are not satisfactory to allow the device to operate.">
       <status abstract="false" inherited="true" concrete="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="/home/rajiv/tango-9.2.2/share/pogo/preferences"/>
+    <preferences docHome="./doc_html" makefileHome="/home/user/tango-9.2.5a/share/pogo/preferences"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/tmcprototype/CentralNode/CentralNode/CONST.py
+++ b/tmcprototype/CentralNode/CentralNode/CONST.py
@@ -2,6 +2,8 @@
 CMD_SET_STOW_MODE = "SetStowMode"
 CMD_SET_STANDBY_MODE = "SetStandbyLPMode"
 CMD_SET_OPERATE_MODE = "SetOperateMode"
+CMD_ASSIGN_RESOURCES = "AssignResources"
+
 
 #Event messages
 EVT_UNKNOWN_SA = "Event from the Unknown Subarray device!"
@@ -18,6 +20,9 @@ ERR_IN_CREATE_PROXY = "Unexpected error in creating proxy of the device "
 ERR_EXE_STOW_CMD = "Unexpected error in executing STOW command "
 ERR_EXE_STANDBY_CMD = "Unexpected error in executing STANDBY Telescope command "
 ERR_EXE_STARTUP_CMD = "Unexpected error in executing STARTUP Telescope command "
+ERR_INVALID_JSON = "Invalid JSON format"
+ERR_JSON_KEY_NOT_FOUND = "JSON key not found "
+
 
 #strings
 #General strings

--- a/tmcprototype/CentralNode/CentralNode/CONST.py
+++ b/tmcprototype/CentralNode/CentralNode/CONST.py
@@ -8,6 +8,7 @@ CMD_ASSIGN_RESOURCES = "AssignResources"
 #Event messages
 EVT_UNKNOWN_SA = "Event from the Unknown Subarray device!"
 EVT_SUBSR_SA_HEALTH_STATE = "healthState"
+EVT_SUBSR_SA_RECEPTOR_ID_LIST = "receptorIDList"
 #
 #Error messages
 ERR_AGGR_HEALTH_STATE = "Unexpected error while aggregating Health state!\n"

--- a/tmcprototype/CentralNode/CentralNode/CentralNode.py
+++ b/tmcprototype/CentralNode/CentralNode/CentralNode.py
@@ -391,7 +391,10 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
 
     @command(
     dtype_in='str', 
-    doc_in="The string in JSON format. The JSON contains following values:\nsubarrayID: DevShort\ndish: JSON object consisting\n- receptorIDList: DevVarStringArray. The individual string should contain dish numbers in string format with preceding zeroes upto 3 digits. E.g. 0001, 0002", 
+    doc_in="The string in JSON format. The JSON contains following values:\nsubarrayID: "
+           "DevShort\ndish: JSON object consisting\n- receptorIDList: DevVarStringArray. "
+           "The individual string should contain dish numbers in string format with "
+           "preceding zeroes upto 3 digits. E.g. 0001, 0002",
     )
     @DebugIt()
     def AssignResources(self, argin):
@@ -405,19 +408,29 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
                                          format with preceding zeroes upto 3 digits. E.g. 0001, 0002.
                       Example:
                       {
-                        'subarrayID': 1,
-                        'dish': {
-                                  'receptorIDList': ["0001", 0002]
+                        "subarrayID": 1,
+                        "dish": {
+                                  "receptorIDList": ["0001", "0002"]
                                 }
                       }
         :return: None.
         """
         try:
+            #serialize the json
             jsonArgument = json.loads(argin)
-            subarrayID= jsonArgument['subarrayID']
+
+            #invoke command on subarray node
+            subarrayID = jsonArgument["subarrayID"]
             subarrayProxy = self.subarray_FQDN_dict[subarrayID]
             print("subarrayProxy: ", subarrayProxy)
-        except KeyError:
+
+            subarrayProxy.command_inout_raw(CONST.CMD_ASSIGN_RESOURCES, json.dumps(jsonArgument["dish"]))
+        except ValueError as json_exception:
+            self.dev_logging(CONST.ERR_INVALID_JSON, int(tango.LogLevel.LOG_ERROR))
+            print(CONST.ERR_INVALID_JSON, json_exception)
+        except KeyError as json_exception:
+            self.dev_logging(CONST.ERR_JSON_KEY_NOT_FOUND, int(tango.LogLevel.LOG_ERROR))
+            print(CONST.ERR_JSON_KEY_NOT_FOUND, json_exception)
 
         pass
         # PROTECTED REGION END #    //  CentralNode.AssignResources

--- a/tmcprototype/CentralNode/CentralNode/CentralNode.py
+++ b/tmcprototype/CentralNode/CentralNode/CentralNode.py
@@ -427,10 +427,10 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
             subarrayProxy.command_inout(CONST.CMD_ASSIGN_RESOURCES, jsonArgument["dish"]["receptorIDList"])
         except ValueError as json_exception:
             self.dev_logging(CONST.ERR_INVALID_JSON, int(tango.LogLevel.LOG_ERROR))
-            self.activityMessage = CONST.ERR_INVALID_JSON
+            self._read_activity_message = CONST.ERR_INVALID_JSON
         except KeyError as json_exception:
             self.dev_logging(CONST.ERR_JSON_KEY_NOT_FOUND, int(tango.LogLevel.LOG_ERROR))
-            self.activityMessage = CONST.ERR_JSON_KEY_NOT_FOUND
+            self._read_activity_message = CONST.ERR_JSON_KEY_NOT_FOUND
         pass
         # PROTECTED REGION END #    //  CentralNode.AssignResources
 

--- a/tmcprototype/CentralNode/CentralNode/CentralNode.py
+++ b/tmcprototype/CentralNode/CentralNode/CentralNode.py
@@ -401,8 +401,10 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
         # PROTECTED REGION ID(CentralNode.AssignResources) ENABLED START #
         """
         This command assigns resources to given subarray. It accepts the subarray id and receptor id list as JSON string.
+        
         :param argin: The string in JSON format. The JSON contains following values:
                       subarrayID: DevShort
+
                       dish: JSON object consisting
                          receptorIDList: DevVarStringArray. The individual string should contain dish numbers in string
                                          format with preceding zeroes upto 3 digits. E.g. 0001, 0002.

--- a/tmcprototype/CentralNode/CentralNode/CentralNode.py
+++ b/tmcprototype/CentralNode/CentralNode/CentralNode.py
@@ -400,24 +400,35 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
     def AssignResources(self, argin):
         # PROTECTED REGION ID(CentralNode.AssignResources) ENABLED START #
         """
-        This command assigns resources to given subarray. It accepts the subarray id and receptor id list as JSON string.
-        
-        :param argin: The string in JSON format. The JSON contains following values:
-                      subarrayID: DevShort
+        This command assigns resources to given subarray. It accepts the subarray id and
+        receptor id list in JSON string format. Upon successful execution, the
+        'receptorIDList' attribute of the given subarray is populated with the given
+        receptors.
 
-                      dish: JSON object consisting
-                         receptorIDList: DevVarStringArray. The individual string should contain dish numbers in string
-                                         format with preceding zeroes upto 3 digits. E.g. 0001, 0002.
-                      Example:
-                      {
-                        "subarrayID": 1,
-                        "dish": {
-                                  "receptorIDList": ["0001", "0002"]
-                                }
-                      }
+        :param argin: The string in JSON format. The JSON contains following values:
+
+
+            subarrayID:
+                DevShort. Mandatory.
+
+            dish:
+                Mandatory JSON object consisting of
+
+                receptorIDList:
+                    DevVarStringArray.
+                    The individual string should contain dish numbers in string format with preceding zeroes upto 3 digits. E.g. 0001, 0002.
+
+            Example:
+                {
+                "subarrayID": 1,
+                "dish": {
+                "receptorIDList": ["0001", "0002"]
+                }
+                }
+
         :return: None.
 
-        Note: From jive, enter input as: {"subarrayID":1,"dish":{"receptorIDList":["0001"]}} without any space
+        Note: From Jive, enter input as: {"subarrayID":1,"dish":{"receptorIDList":["0001"]}} without any space.
         """
         try:
             #serialize the json

--- a/tmcprototype/CentralNode/CentralNode/CentralNode.py
+++ b/tmcprototype/CentralNode/CentralNode/CentralNode.py
@@ -414,24 +414,23 @@ class CentralNode(with_metaclass(DeviceMeta, SKABaseDevice)):
                                 }
                       }
         :return: None.
+
+        Note: From jive, enter input as: {"subarrayID":1,"dish":{"receptorIDList":["0001"]}} without any space
         """
         try:
             #serialize the json
             jsonArgument = json.loads(argin)
 
             #invoke command on subarray node
-            subarrayID = jsonArgument["subarrayID"]
+            subarrayID = int(jsonArgument['subarrayID'])
             subarrayProxy = self.subarray_FQDN_dict[subarrayID]
-            print("subarrayProxy: ", subarrayProxy)
-
-            subarrayProxy.command_inout_raw(CONST.CMD_ASSIGN_RESOURCES, json.dumps(jsonArgument["dish"]))
+            subarrayProxy.command_inout(CONST.CMD_ASSIGN_RESOURCES, jsonArgument["dish"]["receptorIDList"])
         except ValueError as json_exception:
             self.dev_logging(CONST.ERR_INVALID_JSON, int(tango.LogLevel.LOG_ERROR))
-            print(CONST.ERR_INVALID_JSON, json_exception)
+            self.activityMessage = CONST.ERR_INVALID_JSON
         except KeyError as json_exception:
             self.dev_logging(CONST.ERR_JSON_KEY_NOT_FOUND, int(tango.LogLevel.LOG_ERROR))
-            print(CONST.ERR_JSON_KEY_NOT_FOUND, json_exception)
-
+            self.activityMessage = CONST.ERR_JSON_KEY_NOT_FOUND
         pass
         # PROTECTED REGION END #    //  CentralNode.AssignResources
 

--- a/tmcprototype/CentralNode/test/CentralNode_test.py
+++ b/tmcprototype/CentralNode/test/CentralNode_test.py
@@ -270,3 +270,18 @@ class TestCentralNode(object):
                                                      CentralNode.subarrayHealthStateCallback)
         assert CONST.STR_HEALTH_STATE in tango_context.device.activityMessage
         create_subarray2_proxy.unsubscribe_event(eid)
+
+    def test_AssignResources(self, tango_context, create_subarray1_proxy):
+        test_input = \
+            {
+            "subarrayID": 1,
+            "dish":
+                {
+                    "receptorIDList": ["0001", "0002"]
+                }
+            }
+
+        tango_context.device.AssignResources(test_input)
+        eid = create_subarray1_proxy.subscribe_event()
+        assert
+        create_subarray1_proxy.unsubscribe_event(eid)


### PR DESCRIPTION
AssignResources command is implemented in Central Node. The command accepts input in JSON string form, validates the keys and assigns the requested resources to the desired subarray.
Currently it does not have the functionality to detect allocation of already allocated resource.