### PR TITLE
Update subarraynode configure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -286,7 +286,7 @@ services:
     command: >
       sh -c "wait-for-it.sh ${TANGO_HOST} --timeout=30 --strict --
              sudo ln -sf /var/run/rsyslog/dev/log /dev/log &&\
-             tango_admin --ping-device mid-csp/elt/subarray01 10 &&\
+             tango_admin --ping-device mid_csp/elt/subarray_01 10 &&\
              /venv/bin/python /app/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CspSubarrayLeafNode.py 01"
     volumes_from:
     - rsyslog-tmcprototype:rw
@@ -371,7 +371,7 @@ services:
              tango_admin --ping-device mid_d0002/elt/master 10 &&\
              tango_admin --ping-device mid_d0003/elt/master 10 &&\
              tango_admin --ping-device mid_d0004/elt/master 10 &&\
-             tango_admin --ping-device mid-csp/elt/subarray01 10 &&\
+             tango_admin --ping-device mid_csp/elt/subarray_01 10 &&\
              tango_admin --ping-device mid_sdp/elt/subarray_1 10 &&\
              tango_admin --ping-device ska_mid/tm_leaf_node/d0001 10 &&\
              tango_admin --ping-device ska_mid/tm_leaf_node/d0002 10 &&\
@@ -406,7 +406,7 @@ services:
              tango_admin --ping-device mid_d0002/elt/master 10 &&\
              tango_admin --ping-device mid_d0003/elt/master 10 &&\
              tango_admin --ping-device mid_d0004/elt/master 10 &&\
-             tango_admin --ping-device mid-csp/elt/subarray01 10 &&\
+             tango_admin --ping-device mid_csp/elt/subarray_01 10 &&\
              tango_admin --ping-device mid_sdp/elt/subarray_1 10 &&\
              tango_admin --ping-device ska_mid/tm_leaf_node/d0001 10 &&\
              tango_admin --ping-device ska_mid/tm_leaf_node/d0002 10 &&\

--- a/test-harness/Makefile
+++ b/test-harness/Makefile
@@ -29,7 +29,7 @@ test:
 	retry --max=10 -- tango_admin --ping-device ska_mid/tm_subarray_node/1
 	retry --max=10 -- tango_admin --ping-device ska_mid/tm_subarray_node/2
 	retry --max=10 -- tango_admin --ping-device mid_sdp/elt/subarray_1
-	retry --max=10 -- tango_admin --ping-device mid-csp/elt/subarray01
+	retry --max=10 -- tango_admin --ping-device mid_csp/elt/subarray_01
 	retry --max=10 -- tango_admin --ping-device ska_mid/tm_central/central_node
 
 	cd /app/tmcprototype/DishMaster && python setup.py test | tee setup_py_test.stdout

--- a/tmcprototype/CspMasterLeafNode/conftest.py
+++ b/tmcprototype/CspMasterLeafNode/conftest.py
@@ -26,7 +26,7 @@ def tango_context(request):
     klass = getattr(module, "CspMasterLeafNode")
     properties = {'SkaLevel': '3', 'GroupDefinitions': '', 'CentralLoggingTarget': '',
                   'ElementLoggingTarget': '', 'StorageLoggingTarget': 'localhost',
-                  'CspSubarrayNodeFQDN': 'mid-csp/elt/subarray01',
+                  'CspSubarrayNodeFQDN': 'mid_csp/elt/subarray_01',
                   }
     tango_context = DeviceTestContext(klass, properties=properties, process= False)
     tango_context.start()

--- a/tmcprototype/CspSubarray/CspSubarray/CONST.py
+++ b/tmcprototype/CspSubarray/CspSubarray/CONST.py
@@ -52,7 +52,7 @@ STR_COMMAND = "Command :-> "
 STR_CMD_FAILED = "CspSubarrayLeafNode Commandfailed"
 STR_CMD_CALLBK = "CspSubarrayLeafNode Command Callback"
 STR_FALSE = "False"
-PROP_DEF_VAL_CSP_MID_SA1 = "mid-csp/elt/subarray01"
+PROP_DEF_VAL_CSP_MID_SA1 = "mid_csp/elt/subarray_01"
 
 STR_CSPSA_FQDN = "CspSubarrayNodeFQDN :-> "
 

--- a/tmcprototype/CspSubarray/conftest.py
+++ b/tmcprototype/CspSubarray/conftest.py
@@ -27,7 +27,7 @@ def tango_context(request):
     klass = getattr(module, "CspSubarray")
     properties = {'SkaLevel': '2', 'MetricList': 'healthState', 'GroupDefinitions': '',
                   'CentralLoggingTarget': '', 'ElementLoggingTarget': '', 'StorageLoggingTarget': 'localhost',
-                  'CspSubarrayNodeFQDN': "mid-csp/elt/subarray01"
+                  'CspSubarrayNodeFQDN': "mid_csp/elt/subarray_01"
                   }
     tango_context = DeviceTestContext(klass, properties=properties, process=False)
     tango_context.start()

--- a/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode.xmi
+++ b/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode.xmi
@@ -31,7 +31,7 @@
     <deviceProperties name="CspSubarrayNodeFQDN" description="FQDN of the CSP Subarray Node Tango Device Server.">
       <type xsi:type="pogoDsl:StringType"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-      <DefaultPropValue>mid-csp/elt/subarray01</DefaultPropValue>
+      <DefaultPropValue>mid_csp/elt/subarray_01</DefaultPropValue>
     </deviceProperties>
     <commands name="State" description="This command gets the device state (stored in its device_state data member) and returns it to the caller." execMethod="dev_state" displayLevel="OPERATOR" polledPeriod="0">
       <argin description="none">

--- a/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CONST.py
+++ b/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CONST.py
@@ -52,7 +52,7 @@ STR_CMD_FAILED = "CspSubarrayLeafNode Commandfailed"
 STR_CMD_CALLBK = "CspSubarrayLeafNode Command Callback"
 STR_FALSE = "False"
 STR_STARTSCAN_SUCCESS = "Scan command is executed successfully."
-PROP_DEF_VAL_CSP_MID_SA1 = "mid-csp/elt/subarray01"
+PROP_DEF_VAL_CSP_MID_SA1 = "mid_csp/elt/subarray_01"
 STR_START_SCAN_EXEC = "StartScan command execution"
 STR_CSPSA_FQDN = "CspSubarrayNodeFQDN :-> "
 

--- a/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CspSubarrayLeafNode.py
+++ b/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CspSubarrayLeafNode.py
@@ -80,7 +80,7 @@ class CspSubarrayLeafNode(SKABaseDevice):
     # Device Properties
     # -----------------
     CspSubarrayNodeFQDN = device_property(
-        dtype='str', default_value="mid-csp/elt/subarray01"
+        dtype='str', default_value="mid_csp/elt/subarray_01"
     )
 
     # ----------

--- a/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CspSubarrayLeafNode.py
+++ b/tmcprototype/CspSubarrayLeafNode/CspSubarrayLeafNode/CspSubarrayLeafNode.py
@@ -80,7 +80,7 @@ class CspSubarrayLeafNode(SKABaseDevice):
     # Device Properties
     # -----------------
     CspSubarrayNodeFQDN = device_property(
-        dtype='str', default_value="mid_csp/elt/subarray_01"
+        dtype='str', default_value= CONST.PROP_DEF_VAL_CSP_MID_SA1
     )
 
     # ----------

--- a/tmcprototype/CspSubarrayLeafNode/conftest.py
+++ b/tmcprototype/CspSubarrayLeafNode/conftest.py
@@ -32,7 +32,7 @@ def tango_context(request):
     klass = getattr(module, "CspSubarrayLeafNode")
     properties = {'SkaLevel': '3', 'GroupDefinitions': '', 'CentralLoggingTarget': '',
                   'ElementLoggingTarget': '', 'StorageLoggingTarget': 'localhost',
-                  'CspSubarrayNodeFQDN': 'mid-csp/elt/subarray01',
+                  'CspSubarrayNodeFQDN': 'mid_csp/elt/subarray_01',
                   }
     tango_context = DeviceTestContext(klass, properties=properties, process=False)
     tango_context.start()
@@ -53,5 +53,5 @@ def initialize_device(tango_context):
 
 @pytest.fixture(scope="class")
 def create_cspsubarray1_proxy():
-    cspsubarray1_proxy = DeviceProxy("mid-csp/elt/subarray01")
+    cspsubarray1_proxy = DeviceProxy("mid_csp/elt/subarray_01")
     return cspsubarray1_proxy

--- a/tmcprototype/CspSubarrayLeafNode/test/CspSubarrayLeafNode_test.py
+++ b/tmcprototype/CspSubarrayLeafNode/test/CspSubarrayLeafNode_test.py
@@ -56,7 +56,7 @@ class TestCspSubarrayLeafNode(object):
     device = CspSubarrayLeafNode
     properties = {'SkaLevel': '3', 'GroupDefinitions': '', 'CentralLoggingTarget': '',
                   'ElementLoggingTarget': '', 'StorageLoggingTarget': 'localhost',
-                  'CspSubarrayNodeFQDN': 'mid-csp/elt/subarray01',}
+                  'CspSubarrayNodeFQDN': 'mid_csp/elt/subarray_01',}
     empty = None  # Should be []
 
     @classmethod

--- a/tmcprototype/SdpSubarrayLeafNode/SdpSubarrayLeafNode/SdpSubarrayLeafNode.py
+++ b/tmcprototype/SdpSubarrayLeafNode/SdpSubarrayLeafNode/SdpSubarrayLeafNode.py
@@ -87,7 +87,7 @@ class SdpSubarrayLeafNode(with_metaclass(DeviceMeta, SKABaseDevice)):
 
 
     SdpSubarrayNodeFQDN = device_property(
-        dtype='str', default_value="mid_sdp/elt/subarray_1",
+        dtype='str', default_value=CONST.PROP_DEF_VAL_TM_MID_SDP_SA,
         doc='FQDN of the SDP Subarray Node Tango Device Server.',
     )
 

--- a/tmcprototype/SubarrayNode/SubarrayNode.xmi
+++ b/tmcprototype/SubarrayNode/SubarrayNode.xmi
@@ -59,6 +59,16 @@
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <DefaultPropValue>ska_mid/tm_leaf_node/sdp_subarray01</DefaultPropValue>
     </deviceProperties>
+    <deviceProperties name="CspSubarrayNodeFQDN" description="This property stores the FQDN of CSP subarray Node device to which the Subarray Node is associated with.">
+      <type xsi:type="pogoDsl:StringType"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <DefaultPropValue>mid_csp/elt/subarray_01</DefaultPropValue>
+    </deviceProperties>
+    <deviceProperties name="SdpSubarrayNodeFQDN" description="This property stores the FQDN of SDP subarray Node device to which the Subarray Node is associated with.">
+      <type xsi:type="pogoDsl:StringType"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <DefaultPropValue>mid_sdp/elt/subarray_1</DefaultPropValue>
+    </deviceProperties>
     <commands name="Abort" description="Change obsState to ABORTED." execMethod="abort" displayLevel="OPERATOR" polledPeriod="0">
       <argin description="">
         <type xsi:type="pogoDsl:VoidType"/>

--- a/tmcprototype/SubarrayNode/SubarrayNode/CONST.py
+++ b/tmcprototype/SubarrayNode/SubarrayNode/CONST.py
@@ -68,7 +68,6 @@ STR_GRP_DEF_TRACK_FN = "Group devices during Track command :-> "
 
 STR_CONFIGURE_CMD_INVOKED_SA = "Configure command invoked on Subarray"
 STR_TRACK_CMD_INVOKED_SA = "Track command invoked on Subarray"
-
 SCAN_ALREADY_IN_PROGRESS = "Scan is already in progress"
 SCAN_ALREADY_COMPLETED = "Scan is already completed"
 SCAN_NOT_EXECUTED = "Scan can not be executed as Subarray.obsState is not READY."
@@ -101,7 +100,6 @@ STR_SDP_SCAN_INIT = "SDP Scan is initiated."
 STR_CSP_SCAN_INIT = "CSP Scan is initiated."
 STR_SDP_END_SCAN_INIT = "SDP EndScan is initiated."
 STR_CSP_END_SCAN_INIT = "CSP EndScan is initiated."
-
 STR_CSP_SA_HEALTH_OK = "CSP SA health is OK."
 STR_CSP_SA_HEALTH_DEGRADED = "CSP SA health is DEGRADED."
 STR_CSP_SA_HEALTH_FAILED = "CSP SA health is FAILED."
@@ -110,6 +108,9 @@ STR_CSP_SA_LEAF_INIT_SUCCESS = "Csp Subarray Leaf Node initialized successfully.
 STR_SDP_SA_LEAF_INIT_SUCCESS = "Sdp Subarray Leaf Node initialized successfully."
 STR_HEALTH_STATE = "healthState of "
 STR_HEALTH_STATE_UNKNOWN_VAL = "CSPSubarray healthState event returned unknown value \n"
+STR_DELAY_MODEL_SUB_POINT = "delayModelSubscriptionPoint"
+STR_VIS_DESTIN_ADDR_SUB_POINT = "visDestinationAddressSubscriptionPoint"
+STR_CSP_CBFOUTLINK = "cspCbfOutlinkAddress"
 
 
 #Error messages

--- a/tmcprototype/SubarrayNode/SubarrayNode/CONST.py
+++ b/tmcprototype/SubarrayNode/SubarrayNode/CONST.py
@@ -174,3 +174,6 @@ STR_KEY_PB_ID_LIST = "processingBlockIdList"
 PROP_DEF_VAL_TMCSP_MID_SALN = "ska_mid/tm_leaf_node/csp_subarray01"
 PROP_DEF_VAL_TMSDP_MID_SALN = "ska_mid/tm_leaf_node/sdp_subarray01"
 PROP_DEF_VAL_LEAF_NODE_PREFIX = "ska_mid/tm_leaf_node/d"
+PROP_DEF_VAL_CSP_MID_SA1 = "mid_csp/elt/subarray_01"
+PROP_DEF_VAL_SDP_MID_SA1 = "mid_sdp/elt/subarray_1"
+

--- a/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
+++ b/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
@@ -948,6 +948,16 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
             "Subarray Node.",
     )
 
+    CspSubarrayNodeFQDN = device_property(
+        dtype='str', default_value="mid_csp/elt/subarray_01"
+    )
+
+    SdpSubarrayNodeFQDN = device_property(
+        dtype='str', default_value="mid_sdp/elt/subarray_1"
+    )
+
+   
+
     # ----------
     # Attributes
     # ----------
@@ -1143,7 +1153,6 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
         """
         excpt_count = 0
         excpt_msg = []
-
         try:
             self._read_activity_message = CONST.STR_CONFIGURE_IP_ARG + str(argin[0])
             if self._obs_state == CONST.OBS_STATE_ENUM_IDLE:
@@ -1165,6 +1174,9 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
                 del sdpConfiguration["pointing"]
                 del sdpConfiguration["dish"]
                 del sdpConfiguration["csp"]
+                # Add cspCbfOutlinkAddress to SDP configuration
+                sdpConfiguration["sdp"]["configure"][CONST.STR_CSP_CBFOUTLINK] = self.CspSubarrayNodeFQDN + \
+                                                                                 "/cbfOutLink"
                 cmdData = tango.DeviceData()
                 cmdData.insert(tango.DevString, json.dumps(sdpConfiguration))
                 self._sdp_subarray_ln_proxy.command_inout(CONST.CMD_CONFIGURE, cmdData)
@@ -1178,8 +1190,10 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
                 del cspConfiguration["sdp"]
                 # Add delayModelSubscriptionPoint and visDestinationAddressSubscriptionPoint into
                 # cspConfiguration
-                cspConfiguration["csp"][CONST.STR_DELAY_MODEL_SUB_POINT] = "ska_mid/tm_leaf_node/csp_subarray01/delayModel"
-                cspConfiguration["csp"][CONST.STR_VIS_DESTIN_ADDR_SUB_POINT] = "mid_sdp/elt/subarray_1/receiveAddresses"
+                cspConfiguration["csp"][CONST.STR_DELAY_MODEL_SUB_POINT] = self.CspSubarrayLNFQDN + \
+                                                                           "/delayModel"
+                cspConfiguration["csp"][CONST.STR_VIS_DESTIN_ADDR_SUB_POINT] = self.SdpSubarrayNodeFQDN + \
+                                                                               "/receiveAddresses"
                 cmdData = tango.DeviceData()
                 cmdData.insert(tango.DevString, json.dumps(cspConfiguration))
                 self._csp_subarray_ln_proxy.command_inout(CONST.CMD_CONFIGURESCAN, cmdData)

--- a/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
+++ b/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
@@ -1176,6 +1176,10 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
                 del cspConfiguration["pointing"]
                 del cspConfiguration["dish"]
                 del cspConfiguration["sdp"]
+                # Add delayModelSubscriptionPoint and visDestinationAddressSubscriptionPoint into
+                # cspConfiguration
+                cspConfiguration["csp"][CONST.STR_DELAY_MODEL_SUB_POINT] = "ska_mid/tm_leaf_node/csp_subarray01/delayModel"
+                cspConfiguration["csp"][CONST.STR_VIS_DESTIN_ADDR_SUB_POINT] = "mid_sdp/elt/subarray_1/receiveAddresses"
                 cmdData = tango.DeviceData()
                 cmdData.insert(tango.DevString, json.dumps(cspConfiguration))
                 self._csp_subarray_ln_proxy.command_inout(CONST.CMD_CONFIGURESCAN, cmdData)

--- a/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
+++ b/tmcprototype/SubarrayNode/SubarrayNode/SubarrayNode.py
@@ -932,28 +932,28 @@ class SubarrayNode(with_metaclass(DeviceMeta, SKASubarray)):
     # -----------------
 
     DishLeafNodePrefix = device_property(
-        dtype='str', default_value="ska_mid/tm_leaf_node/d",
+        dtype='str', default_value=CONST.PROP_DEF_VAL_LEAF_NODE_PREFIX,
         doc="Device name prefix for the Dish Leaf Node",
     )
 
     CspSubarrayLNFQDN = device_property(
-        dtype='str', default_value="ska_mid/tm_leaf_node/csp_subarray01",
+        dtype='str', default_value= CONST.PROP_DEF_VAL_TMCSP_MID_SALN,
         doc="This property contains the FQDN of the CSP Subarray Leaf Node associated with the "
             "Subarray Node.",
     )
 
     SdpSubarrayLNFQDN = device_property(
-        dtype='str', default_value="ska_mid/tm_leaf_node/sdp_subarray01",
+        dtype='str', default_value= CONST.PROP_DEF_VAL_TMSDP_MID_SALN,
         doc="This property contains the FQDN of the SDP Subarray Leaf Node associated with the "
             "Subarray Node.",
     )
 
     CspSubarrayNodeFQDN = device_property(
-        dtype='str', default_value="mid_csp/elt/subarray_01"
+        dtype='str', default_value= CONST.PROP_DEF_VAL_CSP_MID_SA1
     )
 
     SdpSubarrayNodeFQDN = device_property(
-        dtype='str', default_value="mid_sdp/elt/subarray_1"
+        dtype='str', default_value=CONST.PROP_DEF_VAL_SDP_MID_SA1
     )
 
    

--- a/tmcprototype/devices.json
+++ b/tmcprototype/devices.json
@@ -237,7 +237,7 @@
         "CspSubarray": {
             "01": {
                 "CspSubarray": {
-                    "mid-csp/elt/subarray01": {
+                    "mid_csp/elt/subarray_01": {
                         "attribute_properties": {
                             "adminMode": {
                                 "abs_change": [
@@ -305,12 +305,12 @@
                             },
                             "cspsubarrayHealthState": {
                                 "__root_att": [
-                                    "mid-csp/elt/subarray01/healthState"
+                                    "mid_csp/elt/subarray_01/healthState"
                                 ]
                             },
                             "cspSubarrayObsState": {
                                 "__root_att": [
-                                    "mid-csp/elt/subarray01/obsState"
+                                    "mid_csp/elt/subarray_01/obsState"
                                 ]
                             },
                             "healthState": {
@@ -327,7 +327,7 @@
                         },
                         "properties": {
                             "CspSubarrayNodeFQDN": [
-                                "mid-csp/elt/subarray01"
+                                "mid_csp/elt/subarray_01"
                             ],
                             "SkaLevel": [
                                 "3"
@@ -1120,6 +1120,12 @@
                             "SdpSubarrayLNFQDN": [
                                 "ska_mid/tm_leaf_node/sdp_subarray01"
                             ],
+                            "CspSubarrayNodeFQDN": [
+                                "mid_csp/elt/subarray_01"
+                            ],
+                            "SdpSubarrayNodeFQDN": [
+                                "mid_sdp/elt/subarray_1"
+                            ],
                             "SkaLevel": [
                                 "1"
                             ],
@@ -1190,6 +1196,12 @@
                             ],
                             "SdpSubarrayLNFQDN": [
                                 "ska_mid/tm_leaf_node/sdp_subarray01"
+                            ],
+                             "CspSubarrayNodeFQDN": [
+                                "mid_csp/elt/subarray_01"
+                            ],
+                            "SdpSubarrayNodeFQDN": [
+                                "mid_sdp/elt/subarray_1"
                             ],
                             "SkaLevel": [
                                 "1"


### PR DESCRIPTION
1. Updated SubarrayNode configure command to add SDP receive addresses to JSON string for CSP Configuration. (AT1-281)
 - Added FQDNs of visDestinationAddressSubscriptionPoint and delayModelSubscriptionPoint in SubarrayNode.Configure JSON string.
2. Updated SubarrayNode configure command to add CSP output links for each channel to JSON string for SDP Configuration. (AT1-282)
- Added FQDN of cspCbfOutlinkAddress in SubarrayNode.Configure JSON string.
3. Updated CspSubarray device name from mid-csp/elt/subarray01 => mid_csp/elt/subarray_01.
