### PR TITLE
Story AT1 337: Inject fault in DishMaster

### DIFF
--- a/docker-compose/tmc-docker-compose.yml
+++ b/docker-compose/tmc-docker-compose.yml
@@ -383,7 +383,8 @@ services:
       - rsyslog-tmcprototype:rw
 
   rsyslog-tmcprototype:
-    image: jumanjiman/rsyslog
+#    image: jumanjiman/rsyslog
+    image: https://hub.docker.com/r/jumanjiman/rsyslog
     container_name: ${CONTAINER_NAME_PREFIX}rsyslog
     network_mode: ${NETWORK_MODE}
 

--- a/docker-compose/tmc-docker-compose.yml
+++ b/docker-compose/tmc-docker-compose.yml
@@ -383,8 +383,7 @@ services:
       - rsyslog-tmcprototype:rw
 
   rsyslog-tmcprototype:
-#    image: jumanjiman/rsyslog
-    image: https://hub.docker.com/r/jumanjiman/rsyslog
+    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/rsyslog:latest
     container_name: ${CONTAINER_NAME_PREFIX}rsyslog
     network_mode: ${NETWORK_MODE}
 

--- a/tmcprototype/DishMaster/DishMaster/DishMaster.py
+++ b/tmcprototype/DishMaster/DishMaster/DishMaster.py
@@ -538,11 +538,9 @@ class DishMaster(with_metaclass(DeviceMeta, SKAMaster)):
         return self._toggle_fault
         # PROTECTED REGION END #    //  DishMaster.toggleFault_read
 
-
     def write_toggleFault(self, value):
         # PROTECTED REGION ID(DishMaster.toggleFault_write) ENABLED START #
         self._toggle_fault = value
-
         # PROTECTED REGION END #    //  DishMaster.toggleFault_write
 
     # --------


### PR DESCRIPTION
1. Added toggleFault attribute at DishMaster to enable or disable the fault injection functionality.
2. Updated docker image path for rsyslog to refer to the Nexus repository. 